### PR TITLE
Add support for open_projector command

### DIFF
--- a/UPDeck_OBS.lua
+++ b/UPDeck_OBS.lua
@@ -1070,6 +1070,12 @@ local function process(cData)
 				end
 			end
 		end
+	elseif cmd == "open_projector" then
+		local pType = vParams.type or "preview"
+		local monitor = vParams.monitor or -1
+		local geom = vParams.geometry
+		local name = vParams.name
+		obs.obs_frontend_open_projector(pType, monitor, geom, name)
 	elseif cmd == "filter" then
 		-- enable / disable filter
 		local sceneName = vParams.scene


### PR DESCRIPTION
Added support for open_projector which can open the projector window in
a number of ways

params: type (optional) One of Preview (default), Source, Scene,
StudioProgram, or Multiview (case insensitive)
monitor: (optional) the monitor number, or -1 (default) for a winow.
name: the name of the source or scene to be displayed (ignored for other
projector types)

```
open a projector scene
open_projector
type=scene
name=Laptop Screen
```